### PR TITLE
fix: tsc errors, remove redundant req from test file.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Elysia, type Context } from 'elysia'
+import { Elysia } from 'elysia'
 
 export interface BearerOptions {
     /**
@@ -53,13 +53,16 @@ export const bearer = (
             query: queryName,
             header
         }
-    }).derive({ as: 'global' }, ({ query, headers: { authorization } }) => ({
+    }).derive({ as: 'global' }, ({ query, headers: { authorization: authorizationHeader } }) => ({
         get bearer() {
-            if ((authorization as string)?.startsWith(header))
-                return (authorization as string).slice(header.length + 1)
 
-            const q = query[queryName]
-            if (q) return q
+            if (authorizationHeader?.startsWith(header))
+                return authorizationHeader.slice(header.length + 1)
+
+            const tokenFromQuery = query[queryName]
+            if (tokenFromQuery) return tokenFromQuery;
+
+            return;
         }
     }))
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,9 +2,6 @@ import { Elysia } from 'elysia'
 import { bearer } from '../src'
 
 import { describe, expect, it } from 'bun:test'
-
-const req = (path: string) => new Request(`http://localhost:8080${path}`)
-
 const app = new Elysia()
     .use(bearer())
     .get('/sign', ({ bearer }) => bearer, {
@@ -13,7 +10,7 @@ const app = new Elysia()
                 set.status = 400
                 set.headers[
                     'WWW-Authenticate'
-                ] = `Bearer realm='sign', error="invalid_request"`
+                    ] = `Bearer realm='sign', error="invalid_request"`
 
                 return 'Unauthorized'
             }
@@ -36,7 +33,7 @@ const nonRFC = new Elysia()
                 set.status = 400
                 set.headers[
                     'WWW-Authenticate'
-                ] = `Bearer realm='sign', error="invalid_request"`
+                    ] = `Bearer realm='sign', error="invalid_request"`
 
                 return 'Unauthorized'
             }


### PR DESCRIPTION
![image](https://github.com/elysiajs/elysia-bearer/assets/47170017/c06cada0-8466-49c6-a68d-8b8a63acd7c4)

The `bearer` import comes from index.ts `node_modules/@elysiajs/bearer/src/index.ts` which triggers errors when using tsc for type checking.

- [ ] fix tsc errors,
- [ ] remove redundant constant `req` from test file.